### PR TITLE
Oss : Fix column selector panel going out of the screen when resolution greater than 16:9

### DIFF
--- a/less/base/_datatables.less
+++ b/less/base/_datatables.less
@@ -161,6 +161,7 @@
   overflow-y: auto;
   padding: @spacing-md;
   width: 21%;
+  max-width: 395px;
   opacity: 0;
 
   transform: translate(-30px, 18px);


### PR DESCRIPTION
### What does this PR do?

Fix column selector panel going out of the screen when resolution greater than 16:9

Fixes https://github.com/upfluence/backlog/issues/312

### What are the observable changes?
Column selector panel stay in screen

### Good PR checklist

- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [ ] ~Added/updated documentation~
- [x] Properly labeled
