### PR TITLE
Added: split settings support for column layout

### DIFF
--- a/less/layouts/_split-settings.less
+++ b/less/layouts/_split-settings.less
@@ -32,6 +32,14 @@
   }
 }
 
+.split-settings.split-settings--column {
+  flex-direction: column;
+  .split-settings__info {
+    .margin-bottom-md;
+    .padding-right-none;
+  }
+}
+
 // Will remove when proper documentation will be added.
 // Usage:
 // <div class="split-settings">


### PR DESCRIPTION
### What does this PR do?

Adds the support of displaying as a column to the split-settings layout.
Related to: https://github.com/upfluence/backlog/issues/702

### Good PR checklist

- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [ ] Added/updated documentation
- [ ] Properly labeled
