### PR TITLE
Add floating menu support

### DIFF
--- a/less/base/_all.less
+++ b/less/base/_all.less
@@ -21,3 +21,4 @@
 @import '_toastr';
 @import '_transitions';
 @import '_toggle-switch';
+@import '_floating-menu';

--- a/less/base/_buttons.less
+++ b/less/base/_buttons.less
@@ -360,36 +360,6 @@ as size modifiers.
 }
 
 //
-// Toggle Button (Actually a stylish checkbox)
-//
-.upf-toggle-btn {}
-
-//
-// Larger than x-toggle component's "miedum size", but less than its
-// "large size".
-//
-.upf-toggle-btn .x-toggle-container { width: 4.75em; }
-.upf-toggle-btn .x-toggle-component {
-  display: block;
-}
-
-.upf-toggle-btn .x-toggle-btn {
-  background-color: @upf-gray; // Switch color when OFF
-  border-radius: 20px !important;
-  padding: 2px;
-
-  &:after {
-    border-radius: 30px !important;
-    background-color: @color-text-contrast;
-  }
-}
-
-// Switch color when ON.
-.upf-toggle-btn .x-toggle-container-checked .x-toggle-btn {
-  background-color: @upf-primary-bright-purple !important;
-}
-
-//
 // Radio buttons
 //
 .upf-radio-group {

--- a/less/base/_floating-menu.less
+++ b/less/base/_floating-menu.less
@@ -1,0 +1,76 @@
+@import '../core/_variables';
+
+@keyframes openDropdown {
+  0% {
+    transform: scaleY(0);
+  }
+
+  100% {
+    transform: scaleY(1);
+  }
+}
+
+@keyframes closeDropdown {
+  0% {
+    transform: scale(1);
+  }
+  100% {
+    transform: scale(0);
+  }
+}
+
+.upf-floating-menu {
+  background-color: #ffffff;
+  border-radius: @default-radius;
+  box-shadow: 0 0 1.2rem rgba(0, 0, 0, 0.2);
+
+  display: flex;
+  flex-direction: column;
+
+  overflow: hidden scroll;
+  max-height: 250px;
+  max-width: 350px;
+
+  margin-top: @spacing-xx-sm;
+  padding: @spacing-xxx-sm;
+  position: absolute;
+  z-index: 22;
+
+  ul {
+    padding: 0;
+  }
+
+  &-bottom {
+    overflow: hidden;
+
+    .ql-mention-list {
+      overflow: hidden scroll;
+    }
+  }
+
+  &--visible {
+    animation: openDropdown 0.3s;
+    transform-origin: top center;
+  }
+
+  &--hidden {
+    animation: closeDropdown 0.3s;
+    display: none;
+  }
+}
+
+.upf-floating-menu__item {
+  border-radius: @default-radius;
+  cursor: pointer;
+
+  list-style: none;
+  padding: @spacing-xxx-sm @spacing-xx-sm;
+
+  &:hover {
+    background-color: @upf-gray-light;
+  }
+
+  > li {
+    list-style-type: none;
+  }
+}


### PR DESCRIPTION
### What does this PR do?

Share the floating menu used at multiple places in the software. Although it's mainly used as dropdown container, it can be used as pretty much anything when we need to wrap or a feature that is floating next to its trigger.

When combined the `on-click-outside` Ember modifier, we can easily close it, mimicking a basic dropdown

### What are the observable changes?

<img width="688" alt="Screenshot 2021-07-12 at 15 31 08" src="https://user-images.githubusercontent.com/4022350/125296068-31e0a380-e326-11eb-9988-9ea31250b568.png">

### Good PR checklist

- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [ ] Added/updated documentation
- [x] Properly labeled

### Additional Notes

<!--
    You can add anything you want here, an explanation on the way you built your implementation,
    precisions on the origin of the bug, gotchas you need to mention.
 -->
