### PR TITLE
Use calc to compute spacing variables & their utility classes

### DIFF
--- a/less/core-v2/_variables.less
+++ b/less/core-v2/_variables.less
@@ -18,20 +18,20 @@
   --spacing-px-9: 9px;
   .generate-spacing-vars(60);
   .generate-spacing-vars(@n, @i: 0) when (@i =< @n) {
-    --spacing-px-@{i}: @i * 1px;
+    --spacing-px-@{i}: calc(@i * 1px);
     .margin {
-      &-px-@{i} { margin: @i * 1px; }
-      &-left-px-@{i} { margin-left: @i * 1px; }
-      &-right-px-@{i} { margin-right: @i * 1px; }
-      &-top-px-@{i} { margin-top: @i * 1px; }
-      &-bottom-px-@{i} { margin-bottom: @i * 1px; }
+      &-px-@{i} { margin: calc(@i * 1px); }
+      &-left-px-@{i} { margin-left: calc(@i * 1px); }
+      &-right-px-@{i} { margin-right: calc(@i * 1px); }
+      &-top-px-@{i} { margin-top: calc(@i * 1px); }
+      &-bottom-px-@{i} { margin-bottom: calc(@i * 1px); }
     }
     .padding {
-      &-px-@{i} { padding: @i * 1px; }
-      &-left-px-@{i} { padding-left: @i * 1px; }
-      &-right-px-@{i} { padding-right: @i * 1px; }
-      &-top-px-@{i} { padding-top: @i * 1px; }
-      &-bottom-px-@{i} { padding-bottom: @i * 1px; }
+      &-px-@{i} { padding: calc(@i * 1px); }
+      &-left-px-@{i} { padding-left: calc(@i * 1px); }
+      &-right-px-@{i} { padding-right: calc(@i * 1px); }
+      &-top-px-@{i} { padding-top: calc(@i * 1px); }
+      &-bottom-px-@{i} { padding-bottom: calc(@i * 1px); }
     }
 
     .generate-spacing-vars(@n, (@i + 6));


### PR DESCRIPTION
### What does this PR do?

For some reason, some browsers doesn't seem to appreciate direct calculation in CSS variables, causing them to not be applied. This fixes it by using `calc`.

### What are the observable changes?
<!-- This question could be adequate with multiple use cases, for example: -->

<!-- Frontend: explain the feature created / updated, give instructions telling how to see the change in staging -->
<!-- Performance: what metric should be impacted, link to the right graphana dashboard for exemple -->
<!-- Bug: a given issue trail on sentry should stop happening -->
<!-- Feature: Implements X thrift service / Z HTTP REST API added, provide instructions on how leverage your feature from staging or your workstation -->

### Good PR checklist

- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [ ] Added/updated documentation
- [x] Properly labeled

### Additional Notes

<!--
    You can add anything you want here, an explanation on the way you built your implementation,
    precisions on the origin of the bug, gotchas you need to mention.
 -->
