### PR TITLE
Updated: flex gap generator to 1px instead of 5px gaps

### DIFF
--- a/less/utilities/_flex.less
+++ b/less/utilities/_flex.less
@@ -51,7 +51,7 @@
       &-px-@{i} {
         gap: @i * 1px;
       }
-      .generate-fx-gap(@n, (@i + 5));
+      .generate-fx-gap(@n, (@i + 1));
     }
   }
 }


### PR DESCRIPTION
### What does this PR do?

Updated: flex gap generator to 1px instead of 5px gaps

### Good PR checklist
- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [ ] Added/updated documentation
- [ ] Properly labeled
